### PR TITLE
fix(auth): resolve OAuth code appearing in dashboard URL after login

### DIFF
--- a/src/app/(routes)/(main)/layout.tsx
+++ b/src/app/(routes)/(main)/layout.tsx
@@ -1,5 +1,23 @@
+'use client'
+
+import { Suspense, useEffect } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { AppNavbar } from "@/src/app/components/app-navbar";
 import { ClosetProvider } from "@/src/app/providers/closetContext";
+
+function CodeCleaner() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get('code')) {
+      router.replace(pathname);
+    }
+  }, []);
+
+  return null;
+}
 
 export default function loggedInLayout({
   children,
@@ -9,6 +27,9 @@ export default function loggedInLayout({
   return (
     <ClosetProvider>
       <AppNavbar />
+      <Suspense>
+        <CodeCleaner />
+      </Suspense>
       <div className="h-full">
         {children}
       </div>

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -11,11 +11,6 @@ export async function GET(request: NextRequest) {
     : forwardedHost ? `https://${forwardedHost}` : new URL(request.url).origin
   const code = searchParams.get('code')
 
-  console.log('[auth/callback] request.url:', request.url)
-  console.log('[auth/callback] x-forwarded-host:', forwardedHost)
-  console.log('[auth/callback] resolved origin:', origin)
-  console.log('[auth/callback] code present:', !!code)
-
   if (code) {
     const cookieStore = await cookies()
 
@@ -37,8 +32,6 @@ export async function GET(request: NextRequest) {
     )
 
     const { error } = await supabase.auth.exchangeCodeForSession(code)
-    console.log('[auth/callback] exchangeCodeForSession error:', error)
-
     if (!error) {
       return NextResponse.redirect(`${origin}/dashboard`)
     }

--- a/src/app/supabaseConfig/client.ts
+++ b/src/app/supabaseConfig/client.ts
@@ -2,5 +2,11 @@ import { createBrowserClient } from '@supabase/ssr'
 
 export const supabase = createBrowserClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+  {
+    auth: {
+      detectSessionInUrl: false,
+      flowType: 'pkce',
+    },
+  }
 )


### PR DESCRIPTION
Disable detectSessionInUrl on the browser Supabase client so the server-side /auth/callback route handler is the sole code exchanger. Add CodeCleaner to the (main) layout to strip any stale ?code= param as a safety net. Remove debug logging from the callback route.